### PR TITLE
Fix broken Heading MD Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Conversion tool for turning html and html.erb files into haml.
 This code is currently being used as part of a web html-to-haml conversion tool [here](http://html-to-haml.cfapps.io/).
 Its main purpose is to provide the backend code for that tool, so that the UI and Business logic are completely separate.
 
-##Usage
+## Usage
 Add the following line to your gemfile.
 ```ruby
 gem 'html-to-haml'
@@ -13,14 +13,14 @@ Once you have run `bundle install`, you will need to `require 'html_to_haml/conv
 
 Call `HtmlToHaml::Converter.new(File.read('path/to/file.html.erb').convert` and get the text for a converted haml file.
 
-##Examples
+## Examples
 This gem is currently being used as part of this [html to haml web converter](http://html-to-haml.cfapps.io/).
 You can see the code for the web interface [here](https://github.com/NatashaHull/html-to-haml-web)
 
-###Travis CI
+### Travis CI
 https://travis-ci.org/NatashaHull/html-to-haml
 
-###License
+### License
 --------------------------
 This repository uses the MIT Licencse.
 Copyright (c) [2016] [Natasha Hull-Richter]


### PR DESCRIPTION
Back in March, Github moved to a stricter model for Markdown syntax. The headings were broken as a result. More information: https://githubengineering.com/a-formal-spec-for-github-markdown/